### PR TITLE
Create database tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,68 @@
-# README
+# Olympics API
 
-This README would normally document whatever steps are necessary to get the
-application up and running.
+## Introduction
 
-Things you may want to cover:
+The Olympics API provides analytical insight from the Rio 2016 Summer Olympics. This includes information about every olympian that competed, the youngest and oldest olympians, every sport and its events, and the medalists for each event.
 
-* Ruby version
 
-* System dependencies
+## Initial Setup
 
-* Configuration
+Navigate into your desired directory and execute the following commands to set up the repository locally:
 
-* Database creation
+```
+git clone git@github.com:johnktravers/olympics_api.git
+cd olympics_api
+bundle install
+rake db:{create,migrate}
+rake import:data
+rails server
+```
 
-* Database initialization
+Once the commands have finished executing, open a web browser and navigate to http://localhost:3000. You can now access the API locally.
 
-* How to run the test suite
 
-* Services (job queues, cache servers, search engines, etc.)
+## Running Tests
 
-* Deployment instructions
+To make sure the repository is set up correctly, run the test suite with the following command:
 
-* ...
+```
+bundle exec rspec
+```
+
+
+## Endpoints
+
+- #### `GET /api/v1/olympians`
+
+- #### `GET /api/v1/olympians?age=youngest`
+
+- #### `GET /api/v1/olympians?age=oldest`
+
+- #### `GET /api/v1/olympian_stats`
+
+- #### `GET /api/v1/events`
+
+- #### `GET /api/v1/events/:id/medalists`
+
+
+## Database Schema
+
+<img width="993" alt="olympics_api_schema" src="https://user-images.githubusercontent.com/46035439/75685086-3cc9f500-5c57-11ea-8cad-c854cadfdf2b.png">
+
+
+## Tech Stack
+
+- Ruby on Rails
+- PostgreSQL
+- RSpec
+- Travis CI
+
+
+## How to Contribute
+
+If you would like to make a contribution, please fork the repo and set it up locally using the instructions above. Commit your changes, make a PR to this repo, and I'll get to it shortly. If you have any questions or advice for new features, feel free to reach out to me via my GitHub account below.
+
+
+## Core Contributors
+
+- [John Travers](https://github.com/johnktravers)

--- a/db/migrate/20200302161032_create_teams.rb
+++ b/db/migrate/20200302161032_create_teams.rb
@@ -1,0 +1,9 @@
+class CreateTeams < ActiveRecord::Migration[5.2]
+  def change
+    create_table :teams do |t|
+      t.string :country
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20200302161340_create_sports.rb
+++ b/db/migrate/20200302161340_create_sports.rb
@@ -1,0 +1,9 @@
+class CreateSports < ActiveRecord::Migration[5.2]
+  def change
+    create_table :sports do |t|
+      t.string :name
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20200302161512_create_olympians.rb
+++ b/db/migrate/20200302161512_create_olympians.rb
@@ -1,0 +1,15 @@
+class CreateOlympians < ActiveRecord::Migration[5.2]
+  def change
+    create_table :olympians do |t|
+      t.string :name
+      t.integer :age
+      t.string :sex
+      t.integer :height
+      t.integer :weight
+      t.references :team, foreign_key: true
+      t.references :sport, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20200302161605_create_events.rb
+++ b/db/migrate/20200302161605_create_events.rb
@@ -1,0 +1,10 @@
+class CreateEvents < ActiveRecord::Migration[5.2]
+  def change
+    create_table :events do |t|
+      t.string :name
+      t.references :sport, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20200302162001_create_olympian_events.rb
+++ b/db/migrate/20200302162001_create_olympian_events.rb
@@ -1,0 +1,11 @@
+class CreateOlympianEvents < ActiveRecord::Migration[5.2]
+  def change
+    create_table :olympian_events do |t|
+      t.references :olympian, foreign_key: true
+      t.references :event, foreign_key: true
+      t.integer :medal
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,0 +1,67 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# Note that this schema.rb definition is the authoritative source for your
+# database schema. If you need to create the application database on another
+# system, you should be using db:schema:load, not running all the migrations
+# from scratch. The latter is a flawed and unsustainable approach (the more migrations
+# you'll amass, the slower it'll run and the greater likelihood for issues).
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema.define(version: 2020_03_02_162001) do
+
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "plpgsql"
+
+  create_table "events", force: :cascade do |t|
+    t.string "name"
+    t.bigint "sport_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["sport_id"], name: "index_events_on_sport_id"
+  end
+
+  create_table "olympian_events", force: :cascade do |t|
+    t.bigint "olympian_id"
+    t.bigint "event_id"
+    t.integer "medal"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["event_id"], name: "index_olympian_events_on_event_id"
+    t.index ["olympian_id"], name: "index_olympian_events_on_olympian_id"
+  end
+
+  create_table "olympians", force: :cascade do |t|
+    t.string "name"
+    t.integer "age"
+    t.string "sex"
+    t.integer "height"
+    t.integer "weight"
+    t.bigint "team_id"
+    t.bigint "sport_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["sport_id"], name: "index_olympians_on_sport_id"
+    t.index ["team_id"], name: "index_olympians_on_team_id"
+  end
+
+  create_table "sports", force: :cascade do |t|
+    t.string "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "teams", force: :cascade do |t|
+    t.string "country"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  add_foreign_key "events", "sports"
+  add_foreign_key "olympian_events", "events"
+  add_foreign_key "olympian_events", "olympians"
+  add_foreign_key "olympians", "sports"
+  add_foreign_key "olympians", "teams"
+end


### PR DESCRIPTION
### Pull Request Details
- Creates database with teams, sports, olympians, events, and olympian_events tables
- Adds initial README with setup, testing, endpoints, schema, and contributions sections

### Relevant Issue(s)
- #1 Create database tables

### Test Coverage
- Not applicable

### Manual testing
- Run `rake db:{create,migrate}` and check Postico to see if all five tables exist

### Thoughts/Refactors
- Specific endpoint documentation is still incomplete