### PR TITLE
User can get a list of all olympians

### DIFF
--- a/app/controllers/api/v1/olympians_controller.rb
+++ b/app/controllers/api/v1/olympians_controller.rb
@@ -1,0 +1,8 @@
+class Api::V1::OlympiansController < ApplicationController
+  def index
+    olympians = Olympian.includes(:team, :sport, :olympian_events)
+    serialized_olympians = OlympianSerializer.new(olympians).serialized_json
+    formatted_olympians = OlympianFormatter.new(serialized_olympians).json_response
+    render json: formatted_olympians
+  end
+end

--- a/app/models/olympian.rb
+++ b/app/models/olympian.rb
@@ -14,4 +14,8 @@ class Olympian < ApplicationRecord
   belongs_to :sport
   has_many :olympian_events
   has_many :events, through: :olympian_events
+
+  def total_medals_won
+    olympian_events.where('medal > 0').count
+  end
 end

--- a/app/poros/olympian_formatter.rb
+++ b/app/poros/olympian_formatter.rb
@@ -1,0 +1,14 @@
+class OlympianFormatter
+  def initialize(serialized_olympians)
+    @data = JSON.parse(serialized_olympians)['data']
+  end
+
+  def json_response
+    olympians = data.map { |olympian_data| olympian_data['attributes'] }
+    { 'olympians' => olympians }
+  end
+
+  private
+
+  attr_reader :data
+end

--- a/app/serializers/olympian_serializer.rb
+++ b/app/serializers/olympian_serializer.rb
@@ -1,0 +1,8 @@
+class OlympianSerializer
+  include FastJsonapi::ObjectSerializer
+
+  attributes :name, :team, :age, :sport, :total_medals_won
+
+  attribute :team  { |olympian| olympian.team.country }
+  attribute :sport { |olympian| olympian.sport.name }
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,7 @@
 Rails.application.routes.draw do
-  # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
+  namespace :api do
+    namespace :v1 do
+      get '/olympians', to: 'olympians#index'
+    end
+  end
 end

--- a/spec/factories/events.rb
+++ b/spec/factories/events.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :event do
-    name { Faker::Job.title }
+    name { Faker::Job.unique.title }
     sport
   end
 end

--- a/spec/factories/olympians.rb
+++ b/spec/factories/olympians.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :olympian do
-    name { Faker::Name.name }
+    name { Faker::Name.unique.name }
     age { Faker::Number.between(from: 13, to: 62) }
     sex { Faker::Gender.short_binary_type.capitalize }
     height { Faker::Number.between(from: 150, to: 210) }

--- a/spec/factories/sports.rb
+++ b/spec/factories/sports.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
   factory :sport do
-    name { Faker::Job.field }
+    name { Faker::Job.unique.field }
   end
 end

--- a/spec/factories/teams.rb
+++ b/spec/factories/teams.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
   factory :team do
-    country { Faker::WorldCup.team }
+    country { Faker::WorldCup.unique.team }
   end
 end

--- a/spec/models/olympian_spec.rb
+++ b/spec/models/olympian_spec.rb
@@ -30,4 +30,19 @@ RSpec.describe Olympian, type: :model do
     it { should have_many :olympian_events }
     it { should have_many(:events).through(:olympian_events) }
   end
+
+  describe 'instance methods' do
+    it 'total_medals_won' do
+      olympian = create(:olympian)
+
+      expect(olympian.total_medals_won).to eq(0)
+
+      create_list(:olympian_event, 5, medal: 0, olympian: olympian)
+      create_list(:olympian_event, 2, medal: 1, olympian: olympian)
+      create(:olympian_event, medal: 2, olympian: olympian)
+      create(:olympian_event, medal: 3, olympian: olympian)
+
+      expect(olympian.total_medals_won).to eq(4)
+    end
+  end
 end

--- a/spec/requests/api/v1/olympians_spec.rb
+++ b/spec/requests/api/v1/olympians_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+RSpec.describe 'Olympians endpoint', type: :request do
+  before :each do
+    Faker::UniqueGenerator.clear
+  end
+
+  it 'can see a list of all olympians' do
+    olympian_1 = create(:olympian)
+    create_list(:olympian, 2)
+    olympian_4 = create(:olympian)
+
+    get '/api/v1/olympians'
+
+    expect(response).to be_successful
+
+    olympians = JSON.parse(response.body)['olympians']
+
+    expect(olympians.length).to eq(4)
+
+    expect(olympians[0]['name']).to eq(olympian_1.name)
+    expect(olympians[0]['team']).to eq(olympian_1.team.country)
+    expect(olympians[0]['age']).to eq(olympian_1.age)
+    expect(olympians[0]['sport']).to eq(olympian_1.sport.name)
+    expect(olympians[0]['total_medals_won']).to eq(0)
+
+    expect(olympians[3]['name']).to eq(olympian_4.name)
+    expect(olympians[3]['team']).to eq(olympian_4.team.country)
+    expect(olympians[3]['age']).to eq(olympian_4.age)
+    expect(olympians[3]['sport']).to eq(olympian_4.sport.name)
+    expect(olympians[3]['total_medals_won']).to eq(0)
+  end
+end


### PR DESCRIPTION
### Pull Request Details
- Adds route for `GET /api/v1/olympians` endpoint
- Creates OlympiansController with index action
- Creates OlympianSerializer and OlympianFormatter objects to handle JSON response
- Adds tests for total_medals_won model method and endpoint request/response

### Relevant Issue(s)
- #3 User can get a list of all olympians

### Test Coverage
- 100% (both requests and models)

### Manual testing
- Run local server and visit `/api/v1/olympians` and see that response is correct

### Thoughts/Refactors
- The endpoint takes about 4 seconds to load. Perhaps implement caching/other optimization methods to reduce this load time