### PR TITLE
User can get a list of the youngest olympians

### DIFF
--- a/app/controllers/api/v1/olympians_controller.rb
+++ b/app/controllers/api/v1/olympians_controller.rb
@@ -1,6 +1,16 @@
 class Api::V1::OlympiansController < ApplicationController
   def index
-    olympians = Olympian.includes(:team, :sport, :olympian_events)
+    if params[:age]
+      if params[:age] == 'youngest'
+        olympians = Olympian.youngest_olympians.includes(:team, :sport, :olympian_events)
+      else
+        error = "Invalid request. Please enter either 'youngest' or 'oldest' for the age parameter."
+        return render json: Error.new(error).json, status: 400
+      end
+    else
+      olympians = Olympian.includes(:team, :sport, :olympian_events)
+    end
+
     serialized_olympians = OlympianSerializer.new(olympians).serialized_json
     formatted_olympians = OlympianFormatter.new(serialized_olympians).json_response
     render json: formatted_olympians

--- a/app/models/olympian.rb
+++ b/app/models/olympian.rb
@@ -18,4 +18,9 @@ class Olympian < ApplicationRecord
   def total_medals_won
     olympian_events.where('medal > 0').count
   end
+
+  def self.youngest_olympians
+    youngest_age = order(:age).first.age
+    where(age: youngest_age).order(:id)
+  end
 end

--- a/app/poros/error.rb
+++ b/app/poros/error.rb
@@ -1,0 +1,13 @@
+class Error
+  def initialize(message)
+    @message = message
+  end
+
+  def json
+    { 'error' => message, 'status' => '400 Bad Request' }
+  end
+
+  private
+
+  attr_reader :message
+end

--- a/spec/models/olympian_spec.rb
+++ b/spec/models/olympian_spec.rb
@@ -33,6 +33,8 @@ RSpec.describe Olympian, type: :model do
 
   describe 'instance methods' do
     it 'total_medals_won' do
+      Faker::UniqueGenerator.clear
+
       olympian = create(:olympian)
 
       expect(olympian.total_medals_won).to eq(0)
@@ -43,6 +45,18 @@ RSpec.describe Olympian, type: :model do
       create(:olympian_event, medal: 3, olympian: olympian)
 
       expect(olympian.total_medals_won).to eq(4)
+    end
+  end
+
+  describe 'class methods' do
+    it 'youngest_olympians' do
+      Faker::UniqueGenerator.clear
+
+      olympian_1 = create(:olympian, age: 12)
+      create_list(:olympian, 4)
+      olympian_2 = create(:olympian, age: 12)
+
+      expect(Olympian.youngest_olympians).to eq([olympian_1, olympian_2])
     end
   end
 end

--- a/spec/requests/api/v1/olympians_spec.rb
+++ b/spec/requests/api/v1/olympians_spec.rb
@@ -30,4 +30,42 @@ RSpec.describe 'Olympians endpoint', type: :request do
     expect(olympians[3]['sport']).to eq(olympian_4.sport.name)
     expect(olympians[3]['total_medals_won']).to eq(0)
   end
+
+  it 'can see a list of the youngest olympians' do
+    olympian_1 = create(:olympian, age: 12)
+    create_list(:olympian, 3)
+    olympian_2 = create(:olympian, age: 12)
+
+    get '/api/v1/olympians?age=youngest'
+
+    expect(response).to be_successful
+
+    olympians = JSON.parse(response.body)['olympians']
+
+    expect(olympians.length).to eq(2)
+
+    expect(olympians[0]['name']).to eq(olympian_1.name)
+    expect(olympians[0]['team']).to eq(olympian_1.team.country)
+    expect(olympians[0]['age']).to eq(olympian_1.age)
+    expect(olympians[0]['sport']).to eq(olympian_1.sport.name)
+    expect(olympians[0]['total_medals_won']).to eq(0)
+
+    expect(olympians[1]['name']).to eq(olympian_2.name)
+    expect(olympians[1]['team']).to eq(olympian_2.team.country)
+    expect(olympians[1]['age']).to eq(olympian_2.age)
+    expect(olympians[1]['sport']).to eq(olympian_2.sport.name)
+    expect(olympians[1]['total_medals_won']).to eq(0)
+  end
+
+  it 'sees an error message if the age parameter is invalid' do
+    get '/api/v1/olympians?age=middle'
+
+    expect(response.status).to eq(400)
+
+    error = JSON.parse(response.body)
+
+    message = "Invalid request. Please enter either 'youngest' or 'oldest' for the age parameter."
+    expect(error['error']).to eq(message)
+    expect(error['status']).to eq('400 Bad Request')
+  end
 end


### PR DESCRIPTION
### Pull Request Details
- Adds route for `GET /api/v1/olympians?age=youngest` endpoint
- Modifies OlympiansController index action to account for age parameter
- Creates error PORO for handling sad paths
- Adds tests for youngest_olympians class method and endpoint happy and sad paths

### Relevant Issue(s)
- #4 User can get a list of the youngest olympians

### Test Coverage
- 100% (both requests and models)

### Manual testing
- Run local server and visit `/api/v1/olympians?age=youngest` and see that response is correct
- Run local server and visit `/api/v1/olympians?age=not_youngest` and see an error response

### Thoughts/Refactors
- The conditional for age parameter in the index action is very long. Try to refactor.