### PR TITLE
User can get a list of the oldest olympians

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,9 +34,68 @@ bundle exec rspec
 
 - #### `GET /api/v1/olympians`
 
+This endpoint retrieves all of the olympians that competed in the 2016 games. No request body is necessary.
+
+Response format:
+```
+{
+  "olympians": [
+    {
+      "name": "Maha Abdalsalam",
+      "team": "Egypt",
+      "age": 18,
+      "sport": "Diving"
+      "total_medals_won": 0
+    },
+    {
+      "name": "Ahmad Abughaush",
+      "team": "Jordan",
+      "age": 20,
+      "sport": "Taekwondo"
+      "total_medals_won": 1
+    },
+    {...}
+  ]
+}
+```
+
 - #### `GET /api/v1/olympians?age=youngest`
 
+This endpoint gives back the youngest olympians that competed in the 2016 games. All olympians returned share the same age.
+
+Response format:
+```
+{
+  "olympians": [
+    {
+      "name": "Ana Iulia Dascl",
+      "team": "Romania",
+      "age": 13,
+      "sport": "Swimming"
+      "total_medals_won": 0
+    }
+  ]
+}
+```
+
 - #### `GET /api/v1/olympians?age=oldest`
+
+This endpoint gives back the oldest olympians that competed in the 2016 games. All olympians returned share the same age.
+
+Response format:
+```
+{
+  "olympians": [
+    {
+      "name": "Julie Brougham",
+      "team": "New Zealand",
+      "age": 62,
+      "sport": "Equestrianism"
+      "total_medals_won": 0
+    }
+  ]
+}
+```
 
 - #### `GET /api/v1/olympian_stats`
 

--- a/app/controllers/api/v1/olympians_controller.rb
+++ b/app/controllers/api/v1/olympians_controller.rb
@@ -3,6 +3,8 @@ class Api::V1::OlympiansController < ApplicationController
     if params[:age]
       if params[:age] == 'youngest'
         olympians = Olympian.youngest_olympians.includes(:team, :sport, :olympian_events)
+      elsif params[:age] == 'oldest'
+        olympians = Olympian.oldest_olympians.includes(:team, :sport, :olympian_events)
       else
         error = "Invalid request. Please enter either 'youngest' or 'oldest' for the age parameter."
         return render json: Error.new(error).json, status: 400

--- a/app/models/olympian.rb
+++ b/app/models/olympian.rb
@@ -23,4 +23,9 @@ class Olympian < ApplicationRecord
     youngest_age = order(:age).first.age
     where(age: youngest_age).order(:id)
   end
+
+  def self.oldest_olympians
+    oldest_age = order(age: :desc).first.age
+    where(age: oldest_age).order(:id)
+  end
 end

--- a/spec/models/olympian_spec.rb
+++ b/spec/models/olympian_spec.rb
@@ -49,14 +49,24 @@ RSpec.describe Olympian, type: :model do
   end
 
   describe 'class methods' do
-    it 'youngest_olympians' do
+    before :each do
       Faker::UniqueGenerator.clear
+    end
 
+    it 'youngest_olympians' do
       olympian_1 = create(:olympian, age: 12)
       create_list(:olympian, 4)
       olympian_2 = create(:olympian, age: 12)
 
       expect(Olympian.youngest_olympians).to eq([olympian_1, olympian_2])
+    end
+
+    it 'oldest_olympians' do
+      olympian_1 = create(:olympian, age: 63)
+      create_list(:olympian, 4)
+      olympian_2 = create(:olympian, age: 63)
+
+      expect(Olympian.oldest_olympians).to eq([olympian_1, olympian_2])
     end
   end
 end

--- a/spec/requests/api/v1/olympians_spec.rb
+++ b/spec/requests/api/v1/olympians_spec.rb
@@ -57,6 +57,32 @@ RSpec.describe 'Olympians endpoint', type: :request do
     expect(olympians[1]['total_medals_won']).to eq(0)
   end
 
+  it 'can see a list of the oldest olympians' do
+    olympian_1 = create(:olympian, age: 63)
+    create_list(:olympian, 3)
+    olympian_2 = create(:olympian, age: 63)
+
+    get '/api/v1/olympians?age=oldest'
+
+    expect(response).to be_successful
+
+    olympians = JSON.parse(response.body)['olympians']
+
+    expect(olympians.length).to eq(2)
+
+    expect(olympians[0]['name']).to eq(olympian_1.name)
+    expect(olympians[0]['team']).to eq(olympian_1.team.country)
+    expect(olympians[0]['age']).to eq(olympian_1.age)
+    expect(olympians[0]['sport']).to eq(olympian_1.sport.name)
+    expect(olympians[0]['total_medals_won']).to eq(0)
+
+    expect(olympians[1]['name']).to eq(olympian_2.name)
+    expect(olympians[1]['team']).to eq(olympian_2.team.country)
+    expect(olympians[1]['age']).to eq(olympian_2.age)
+    expect(olympians[1]['sport']).to eq(olympian_2.sport.name)
+    expect(olympians[1]['total_medals_won']).to eq(0)
+  end
+
   it 'sees an error message if the age parameter is invalid' do
     get '/api/v1/olympians?age=middle'
 


### PR DESCRIPTION
### Pull Request Details
- Modifies OlympiansController index action to account for `oldest` age parameter
- Adds tests for oldest_olympians class method and endpoint happy path
- Updates the documentation for olympian-related endpoints

### Relevant Issue(s)
- #5 User can get a list of the oldest olympians

### Test Coverage
- 100% (both requests and models)

### Manual testing
- Run local server and visit `/api/v1/olympians?age=oldest` and see that response is correct
- Run local server and visit `/api/v1/olympians?age=not_oldest` and see an error response

### Thoughts/Refactors
- The conditional for age parameter in the index action is very long. Try to refactor.