### PR TITLE
User can get olympian statistics

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Response format:
       "name": "Ana Iulia Dascl",
       "team": "Romania",
       "age": 13,
-      "sport": "Swimming"
+      "sport": "Swimming",
       "total_medals_won": 0
     }
   ]
@@ -90,7 +90,7 @@ Response format:
       "name": "Julie Brougham",
       "team": "New Zealand",
       "age": 62,
-      "sport": "Equestrianism"
+      "sport": "Equestrianism",
       "total_medals_won": 0
     }
   ]
@@ -98,6 +98,23 @@ Response format:
 ```
 
 - #### `GET /api/v1/olympian_stats`
+
+This endpoint gives a set of statistics for all olympians that competed, including the total number of competitors, average weight (split by biological sex), and average age.
+
+Response format:
+```
+{
+  "olympian_stats": {
+    "total_competing_olympians": 3120
+    "average_weight:" {
+      "unit": "kg",
+      "male_olympians": 75.4,
+      "female_olympians": 70.2
+    },
+    "average_age:" 26.2
+  }
+}
+```
 
 - #### `GET /api/v1/events`
 

--- a/app/controllers/api/v1/olympian_stats_controller.rb
+++ b/app/controllers/api/v1/olympian_stats_controller.rb
@@ -1,0 +1,7 @@
+class Api::V1::OlympianStatsController < ApplicationController
+  def show
+    olympians = Olympian.all
+    stats = OlympianStats.new(olympians).json_response
+    render json: stats
+  end
+end

--- a/app/models/olympian.rb
+++ b/app/models/olympian.rb
@@ -28,4 +28,16 @@ class Olympian < ApplicationRecord
     oldest_age = order(age: :desc).first.age
     where(age: oldest_age).order(:id)
   end
+
+  def self.total_competing_olympians
+    count
+  end
+
+  def self.average_weight_by_sex(sex)
+    where(sex: sex).average(:weight)
+  end
+
+  def self.average_age
+    average(:age)
+  end
 end

--- a/app/poros/olympian_stats.rb
+++ b/app/poros/olympian_stats.rb
@@ -1,0 +1,23 @@
+class OlympianStats
+  def initialize(olympians)
+    @olympians = olympians
+  end
+
+  def json_response
+    {
+      'olympian_stats' => {
+        'total_competing_olympians' => olympians.total_competing_olympians,
+        'average_weight' => {
+          'unit' => 'kg',
+          'male_olympians' => olympians.average_weight_by_sex('M').to_f.round(1),
+          'female_olympians' => olympians.average_weight_by_sex('F').to_f.round(1)
+        },
+        'average_age' => olympians.average_age.to_f.round(1)
+      }
+    }
+  end
+
+  private
+
+  attr_reader :olympians
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,8 @@
 Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
-      get '/olympians', to: 'olympians#index'
+      get '/olympians',      to: 'olympians#index'
+      get '/olympian_stats', to: 'olympian_stats#show'
     end
   end
 end

--- a/spec/models/olympian_spec.rb
+++ b/spec/models/olympian_spec.rb
@@ -68,5 +68,33 @@ RSpec.describe Olympian, type: :model do
 
       expect(Olympian.oldest_olympians).to eq([olympian_1, olympian_2])
     end
+
+    it 'total_competing_olympians' do
+      create_list(:olympian, 8)
+
+      expect(Olympian.total_competing_olympians).to eq(8)
+    end
+
+    it 'average_weight_by_sex' do
+      create(:olympian, sex: 'M', weight: 75)
+      create(:olympian, sex: 'M', weight: 92)
+      create(:olympian, sex: 'M', weight: 54)
+      create(:olympian, sex: 'F', weight: 45)
+      create(:olympian, sex: 'F', weight: 95)
+      create(:olympian, sex: 'F', weight: 111)
+
+      expect(Olympian.average_weight_by_sex('M').round(2)).to eq(73.67)
+      expect(Olympian.average_weight_by_sex('F').round(2)).to eq(83.67)
+    end
+
+    it 'average_age' do
+      create(:olympian, age: 24)
+      create(:olympian, age: 35)
+      create(:olympian, age: 29)
+      create(:olympian, age: 17)
+      create(:olympian, age: 24)
+
+      expect(Olympian.average_age).to eq(25.8)
+    end
   end
 end

--- a/spec/requests/api/v1/olympian_stats_spec.rb
+++ b/spec/requests/api/v1/olympian_stats_spec.rb
@@ -1,0 +1,28 @@
+require 'rails_helper'
+
+RSpec.describe 'Olympian statistics endpoint', type: :request do
+  it 'can get statistics across all olympians' do
+    Faker::UniqueGenerator.clear
+
+    create(:olympian, age: 24, sex: 'M', height: 190, weight: 75)
+    create(:olympian, age: 35, sex: 'M', height: 160, weight: 92)
+    create(:olympian, age: 29, sex: 'M', height: 183, weight: 54)
+    create(:olympian, age: 17, sex: 'M', height: 210, weight: 150)
+    create(:olympian, age: 24, sex: 'F', height: 150, weight: 45)
+    create(:olympian, age: 27, sex: 'F', height: 200, weight: 95)
+    create(:olympian, age: 18, sex: 'F', height: 186, weight: 111)
+    create(:olympian, age: 31, sex: 'F', height: 171, weight: 82)
+
+    get '/api/v1/olympian_stats'
+
+    expect(response).to be_successful
+
+    stats = JSON.parse(response.body)['olympian_stats']
+
+    expect(stats['total_competing_olympians']).to eq(8)
+    expect(stats['average_weight']['unit']).to eq('kg')
+    expect(stats['average_weight']['male_olympians']).to eq(92.8)
+    expect(stats['average_weight']['female_olympians']).to eq(83.3)
+    expect(stats['average_age']).to eq(25.6)
+  end
+end


### PR DESCRIPTION
### Pull Request Details
- Creates OlympianStats controller with show action for `/api/v1/olympian_stats` endpoint
- Creates OlympianStats PORO for formatting statistics into JSON
- Adds tests for olympian statistics class methods and endpoint happy path

### Relevant Issue(s)
- #6 User can get olympian statistics

### Test Coverage
- 100% (both requests and models)

### Manual testing
- Run local server and visit `/api/v1/olympian_stats` and see that response is correct

### Thoughts/Refactors
- Add a `team` parameter would be relatively easy to get the statistics for olympians belonging to a specific team