### PR TITLE
User can get a list of all olympic events

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ bundle exec rspec
 
 - #### `GET /api/v1/olympians`
 
-This endpoint retrieves all of the olympians that competed in the 2016 games. No request body is necessary.
+This endpoint retrieves all of the olympians that competed in the 2016 games. Olympians are listed in alphabetical order by last name.
 
 Response format:
 ```
@@ -117,6 +117,36 @@ Response format:
 ```
 
 - #### `GET /api/v1/events`
+
+This endpoint lists all of the events that were open for competition during the 2016 games, organized by sport and listed in alphabetical order.
+
+Response format:
+```
+{
+  "events": [
+    {
+      "sport": "Archery",
+      "events": [
+        "Archery Men's Individual",
+        "Archery Men's Team",
+        "Archery Women's Individual",
+        "Archery Women's Team"
+      ]
+    },
+    {
+      "sport": "Badminton",
+      "events": [
+        "Badminton Men's Doubles",
+        "Badminton Men's Singles",
+        "Badminton Mixed Doubles",
+        "Badminton Women's Doubles",
+        "Badminton Women's Singles"
+      ]
+    },
+    {...}
+  ]
+}
+```
 
 - #### `GET /api/v1/events/:id/medalists`
 

--- a/app/controllers/api/v1/events_controller.rb
+++ b/app/controllers/api/v1/events_controller.rb
@@ -1,0 +1,7 @@
+class Api::V1::EventsController < ApplicationController
+  def index
+    sports = Sport.includes(:events).order(:name)
+    formatted_events = EventFormatter.new(sports).json_response
+    render json: formatted_events
+  end
+end

--- a/app/poros/event_formatter.rb
+++ b/app/poros/event_formatter.rb
@@ -1,0 +1,20 @@
+class EventFormatter
+  def initialize(sports)
+    @sports = sports
+  end
+
+  def json_response
+    events = sports.map do |sport|
+      {
+        'sport' => sport.name,
+        'events' => sport.events.order(:name).pluck(:name)
+      }
+    end
+
+    { 'events' => events }
+  end
+
+  private
+
+  attr_reader :sports
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,7 @@ Rails.application.routes.draw do
     namespace :v1 do
       get '/olympians',      to: 'olympians#index'
       get '/olympian_stats', to: 'olympian_stats#show'
+      get '/events',         to: 'events#index'
     end
   end
 end

--- a/spec/requests/api/v1/events_spec.rb
+++ b/spec/requests/api/v1/events_spec.rb
@@ -1,0 +1,34 @@
+require 'rails_helper'
+
+RSpec.describe 'Events endpoint', type: :request do
+  before :each do
+    Faker::UniqueGenerator.clear
+  end
+
+  it 'can see a list of all events by sport' do
+    sport_1 = create(:sport, name: 'Badminton')
+    sport_2 = create(:sport, name: 'Archery')
+
+    event_1 = create(:event, sport: sport_1, name: 'Badminton Mixed Doubles')
+    event_2 = create(:event, sport: sport_1, name: 'Badminton Men\'s Doubles')
+    event_3 = create(:event, sport: sport_1, name: 'Badminton Women\'s Singles')
+    event_4 = create(:event, sport: sport_2, name: 'Archery Men\'s Team')
+    event_5 = create(:event, sport: sport_2, name: 'Arcehry Men\'s Individual')
+
+    get '/api/v1/events'
+
+    expect(response).to be_successful
+
+    events = JSON.parse(response.body)['events']
+
+    expect(events[0]['sport']).to eq(sport_2.name)
+    expect(events[0]['events'][0]).to eq(event_5.name)
+    expect(events[0]['events'][1]).to eq(event_4.name)
+
+    expect(events[1]['sport']).to eq(sport_1.name)
+    expect(events[1]['events'][0]).to eq(event_2.name)
+    expect(events[1]['events'][1]).to eq(event_1.name)
+    expect(events[1]['events'][2]).to eq(event_3.name)
+
+  end
+end


### PR DESCRIPTION
### Pull Request Details
- Adds route to `/api/v1/events`
- Creates EventsController with index action
- Creates event formatter PORO for handling the JSON response
- Adds tests endpoint happy path

### Relevant Issue(s)
- #7 User can get a list of all olympic events

### Test Coverage
- 100% (both requests and models)

### Manual testing
- Run local server and visit `/api/v1/events` and see that response is correct

### Thoughts/Refactors
- None