### PR TITLE
User can get a list of medalists for an event

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,29 @@ Response format:
 
 - #### `GET /api/v1/events/:id/medalists`
 
+This endpoint returns the medalists for the event matching the given ID. Medalists are sorted by medal type and alphabetically by last name. Because this is sample data, not all events will have a complete list of medalists.
+
+Response format:
+```
+{
+  "event": "Swimming Men's 200 metres Breaststroke",
+  "medalists": [
+    {
+      "name": "Dmitry Igorevich Balandin",
+      "team": "Kazakhstan",
+      "age": 21,
+      "medal": "Gold"
+    },
+    {
+      "name": "Anton Mikhaylovich Chupkov",
+      "team": "Russia",
+      "age": 19,
+      "medal": "Bronze"
+    }
+  ]
+}
+```
+
 
 ## Database Schema
 

--- a/app/controllers/api/v1/events_controller.rb
+++ b/app/controllers/api/v1/events_controller.rb
@@ -4,4 +4,21 @@ class Api::V1::EventsController < ApplicationController
     formatted_events = EventFormatter.new(sports).json_response
     render json: formatted_events
   end
+
+  def show
+    event = Event.find_by(id: params[:id])
+    if event
+      medalists = Olympian
+        .includes(:team)
+        .joins(:olympian_events)
+        .where('olympian_events.medal > 0 AND olympian_events.event_id = ?', event.id)
+        .order('olympian_events.medal DESC, olympians.id')
+
+      formatted_medalists = MedalistFormatter.new(event, medalists).json_response
+      render json: formatted_medalists
+    else
+      error = 'Invalid event ID. Please try again with an integer between 1 and 305.'
+      return render json: Error.new(error).json, status: 400
+    end
+  end
 end

--- a/app/poros/medalist_formatter.rb
+++ b/app/poros/medalist_formatter.rb
@@ -1,0 +1,26 @@
+class MedalistFormatter
+  def initialize(event, medalists)
+    @event = event
+    @medalists = medalists
+  end
+
+  def json_response
+    medalist_info = medalists.map do |medalist|
+      {
+        'name' => medalist.name,
+        'team' => medalist.team.country,
+        'age' => medalist.age,
+        'medal' => medalist.olympian_events.where(event_id: event.id)[0].medal.capitalize
+      }
+    end
+
+    {
+      'event' => event.name,
+      'medalists' => medalist_info
+    }
+  end
+
+  private
+
+  attr_reader :event, :medalists
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,9 +1,10 @@
 Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
-      get '/olympians',      to: 'olympians#index'
-      get '/olympian_stats', to: 'olympian_stats#show'
-      get '/events',         to: 'events#index'
+      get '/olympians',            to: 'olympians#index'
+      get '/olympian_stats',       to: 'olympian_stats#show'
+      get '/events',               to: 'events#index'
+      get '/events/:id/medalists', to: 'events#show'
     end
   end
 end

--- a/spec/requests/api/v1/events_spec.rb
+++ b/spec/requests/api/v1/events_spec.rb
@@ -29,6 +29,49 @@ RSpec.describe 'Events endpoint', type: :request do
     expect(events[1]['events'][0]).to eq(event_2.name)
     expect(events[1]['events'][1]).to eq(event_1.name)
     expect(events[1]['events'][2]).to eq(event_3.name)
+  end
 
+  it 'can see a list of medalists for a specific event' do
+    event = create(:event, name: 'Badminton Women\'s Singles')
+    olympians = create_list(:olympian, 4)
+    olympians.each_with_index do |olympian, i|
+      create(:olympian_event, olympian: olympian, event: event, medal: i)
+    end
+
+    get "/api/v1/events/#{event.id}/medalists"
+
+    expect(response).to be_successful
+
+    event = JSON.parse(response.body)
+
+    expect(event['event']).to eq('Badminton Women\'s Singles')
+    expect(event['medalists'].length).to eq(3)
+
+    expect(event['medalists'][0]['name']).to eq(olympians[3].name)
+    expect(event['medalists'][0]['team']).to eq(olympians[3].team.country)
+    expect(event['medalists'][0]['age']).to eq(olympians[3].age)
+    expect(event['medalists'][0]['medal']).to eq('Gold')
+
+    expect(event['medalists'][1]['name']).to eq(olympians[2].name)
+    expect(event['medalists'][1]['team']).to eq(olympians[2].team.country)
+    expect(event['medalists'][1]['age']).to eq(olympians[2].age)
+    expect(event['medalists'][1]['medal']).to eq('Silver')
+
+    expect(event['medalists'][2]['name']).to eq(olympians[1].name)
+    expect(event['medalists'][2]['team']).to eq(olympians[1].team.country)
+    expect(event['medalists'][2]['age']).to eq(olympians[1].age)
+    expect(event['medalists'][2]['medal']).to eq('Bronze')
+  end
+
+  it 'sees an error message if the event id is invalid' do
+    get '/api/v1/events/306/medalists'
+
+    expect(response.status).to eq(400)
+
+    error = JSON.parse(response.body)
+
+    message = 'Invalid event ID. Please try again with an integer between 1 and 305.'
+    expect(error['error']).to eq(message)
+    expect(error['status']).to eq('400 Bad Request')
   end
 end


### PR DESCRIPTION
### Pull Request Details
- Adds route for `/api/v1/events/:id/medalists` endpoint
- Adds EventsController show action to list event with medalists
- Creates medalist formatter PORO to format the JSON response
- Adds tests for endpoint happy and sad paths

### Relevant Issue(s)
- #8 User can get a list of medalists for an event

### Test Coverage
- 100% (both requests and models)

### Manual testing
- Run local server and visit `/api/v1/events/:id/medalists` with an id between 1 and 305 and see if the response comes back correctly formatted
- Run local server and visit `/api/v1/events/306/medalists` and see an error response

### Thoughts/Refactors
- None